### PR TITLE
Allow deep cloning of tagged fields to be suppressed

### DIFF
--- a/DeepCloner.Core/DeepClonerExtensions.cs
+++ b/DeepCloner.Core/DeepClonerExtensions.cs
@@ -1,4 +1,4 @@
-﻿using DeepCloner.Core.Helpers;
+using DeepCloner.Core.Helpers;
 using JetBrains.Annotations;
 
 namespace DeepCloner.Core;
@@ -43,5 +43,15 @@ public static class DeepClonerExtensions
     public static T ShallowClone<T>(this T obj)
     {
         return ShallowClonerGenerator.CloneObject(obj);
+    }
+
+    public static void SetSuppressedAttributes(params Type[]suppressedAttributes)
+    {
+            foreach (Type type in suppressedAttributes)
+            {
+                if (!type.IsSubclassOf(typeof(Attribute)))
+                    throw new Exception("Bad argument to SetSuppressedAttributes. Type not derived from Attribute class");
+            }
+        DeepClonerGenerator.SuppressedAttributeTypes = suppressedAttributes;
     }
 }

--- a/DeepCloner.Core/Helpers/DeepClonerExprGenerator.cs
+++ b/DeepCloner.Core/Helpers/DeepClonerExprGenerator.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Concurrent;
+using System.Collections.Concurrent;
 using System.Linq.Expressions;
 using System.Reflection;
 
@@ -120,34 +120,43 @@ internal static class DeepClonerExprGenerator
 
         foreach (var fieldInfo in fi)
         {
-            if (!DeepClonerSafeTypes.CanReturnSameObject(fieldInfo.FieldType))
+            if (FieldIsSuppressed(fieldInfo))
             {
-                var methodInfo = fieldInfo.FieldType.IsValueType()
-                    ? typeof(DeepClonerGenerator).GetPrivateStaticMethod(nameof(DeepClonerGenerator.CloneStructInternal))!
-                        .MakeGenericMethod(fieldInfo.FieldType)
-                    : typeof(DeepClonerGenerator).GetPrivateStaticMethod(nameof(DeepClonerGenerator.CloneClassInternal))!;
-
-                var get = Expression.Field(fromLocal, fieldInfo);
-
-                // toLocal.Field = Clone...Internal(fromLocal.Field)
-                var call = (Expression)Expression.Call(methodInfo, get, state);
-                if (!fieldInfo.FieldType.IsValueType())
-                    call = Expression.Convert(call, fieldInfo.FieldType);
-
-                // should handle specially
-                // todo: think about optimization, but it rare case
-                var isReadonly = _readonlyFields.GetOrAdd(fieldInfo, f => f.IsInitOnly);
-                if (isReadonly)
+                // Don't clone; instead set the field to its default value (which will usually be "null" for
+                // non-value types).
+                expressionList.Add(Expression.Assign(Expression.Field(toLocal, fieldInfo), Expression.Default(fieldInfo.FieldType)));
+            }
+            else
+            {
+                if (!DeepClonerSafeTypes.CanReturnSameObject(fieldInfo.FieldType))
                 {
-                    expressionList.Add(Expression.Call(
-                                           Expression.Constant(fieldInfo),
-                                           _fieldSetMethod,
-                                           Expression.Convert(toLocal, typeof(object)),
-                                           Expression.Convert(call, typeof(object))));
-                }
-                else
-                {
-                    expressionList.Add(Expression.Assign(Expression.Field(toLocal, fieldInfo), call));
+                    var methodInfo = fieldInfo.FieldType.IsValueType()
+                        ? typeof(DeepClonerGenerator).GetPrivateStaticMethod(nameof(DeepClonerGenerator.CloneStructInternal))!
+                            .MakeGenericMethod(fieldInfo.FieldType)
+                        : typeof(DeepClonerGenerator).GetPrivateStaticMethod(nameof(DeepClonerGenerator.CloneClassInternal))!;
+
+                    var get = Expression.Field(fromLocal, fieldInfo);
+
+                    // toLocal.Field = Clone...Internal(fromLocal.Field)
+                    var call = (Expression)Expression.Call(methodInfo, get, state);
+                    if (!fieldInfo.FieldType.IsValueType())
+                        call = Expression.Convert(call, fieldInfo.FieldType);
+
+                    // should handle specially
+                    // todo: think about optimization, but it rare case
+                    var isReadonly = _readonlyFields.GetOrAdd(fieldInfo, f => f.IsInitOnly);
+                    if (isReadonly)
+                    {
+                        expressionList.Add(Expression.Call(
+                                               Expression.Constant(fieldInfo),
+                                               _fieldSetMethod,
+                                               Expression.Convert(toLocal, typeof(object)),
+                                               Expression.Convert(call, typeof(object))));
+                    }
+                    else
+                    {
+                        expressionList.Add(Expression.Assign(Expression.Field(toLocal, fieldInfo), call));
+                    }
                 }
             }
         }
@@ -161,6 +170,19 @@ internal static class DeepClonerExprGenerator
         blockParams.Add(toLocal);
 
         return Expression.Lambda(funcType, Expression.Block(blockParams, expressionList), from, state).Compile();
+    }
+
+    private static bool FieldIsSuppressed(FieldInfo fieldInfo)
+    {
+        if (DeepClonerGenerator.SuppressedAttributeTypes != null)
+        {
+            foreach (Type attrType in DeepClonerGenerator.SuppressedAttributeTypes)
+            {
+                if (fieldInfo.GetCustomAttribute(attrType, false) != null)
+                    return true;
+            }
+        }
+        return false;
     }
 
     private static object GenerateProcessArrayMethod(Type type)

--- a/DeepCloner.Core/Helpers/DeepClonerGenerator.cs
+++ b/DeepCloner.Core/Helpers/DeepClonerGenerator.cs
@@ -1,4 +1,4 @@
-﻿namespace DeepCloner.Core.Helpers;
+namespace DeepCloner.Core.Helpers;
 
 internal static class DeepClonerGenerator
 {
@@ -219,4 +219,7 @@ internal static class DeepClonerGenerator
         if (cloner == null) return objTo;
         return cloner(objFrom, objTo, new());
     }
+
+    [ThreadStatic]
+    internal static Type[]? SuppressedAttributeTypes = null;
 }


### PR DESCRIPTION
This modification allows the user to suppress cloning of fields which have been given specific attribute tags. I would like this feature because our application has been using serialization and deserialization with BinaryFormatter to clone objects. As you probably are aware, Microsoft will be removing support for BinaryFormatter with the release of .NET 9 later this year, so we needed an alternative cloning strategy. DeepCloner works very well overall, but in our case there are fields we do NOT want cloned. These have been tagged with the "NonSerialized" attribute, and so were not copied in the serialization/deserialization process. It would be very convenient for us if these fields could continue to not be cloned.

This pull request allows the developer to indicate that fields tagged with specified attributes should not be cloned. This is done by calling, for example,  `DeepClonerExtensions.SetSuppressedAttributes(typeof(NonSerializedAttribute));` before doing the actual cloning. Arguments are passed using the "params" keyword, so it is possible to pass multiple attribute types, for example            ` DeepClonerExtensions.SetSuppressedAttributes(typeof(NonSerializedAttribute), typeof(JsonIgnoreAttribute));`. The settings are held in thread-local storage, so each thread needs to make this setting.

Let me know what you think. If you don't like this change, we can continue to work with a fork of your code. It would be a bit tidier for us if we could use your pre-built nuget package, but that's certainly not essential.