### PR TITLE
fixed bug: some types may occur NRE from DeepClonerSafeTypes.CanRetur…

### DIFF
--- a/DeepCloner.Core.Tests/UnnamedType.cs
+++ b/DeepCloner.Core.Tests/UnnamedType.cs
@@ -1,0 +1,43 @@
+﻿using System.Runtime.InteropServices;
+
+namespace DeepCloner.Core.Tests;
+
+[TestFixture]
+public class UnnamedType
+{
+    private unsafe class UnnamedTypeContainer
+    {
+        public int Value;
+        public object? Object;
+        //FullName of this type may be null
+        public delegate*<IServiceProvider, object> Builder;
+    }
+
+    [Test]
+    public unsafe void UnnamedTypeTest()
+    {
+        //Arrange
+        var array = new[] { 1, 2, 3 };
+        var builder = (IntPtr)GCHandle.Alloc(array, GCHandleType.Pinned);
+        var obj = new UnnamedTypeContainer()
+        {
+            Value = 1,
+            Object = new object(),
+            Builder = (delegate*<IServiceProvider, object>)builder
+        };
+        //Act
+        var result = obj.DeepClone();
+        //Assert
+        Assert.Multiple(() =>
+        {
+            // UnnamedTypeContainer is cloned
+            Assert.That(result, Is.Not.EqualTo(obj));
+            // Value is copied
+            Assert.That(result.Value, Is.EqualTo(obj.Value));
+            // Object is cloned
+            Assert.That(result.Object, Is.Not.EqualTo(obj.Object));
+            // Builder references same instance
+            Assert.That(result.Builder == obj.Builder, Is.True);
+        });
+    }
+}

--- a/DeepCloner.Core/Helpers/DeepClonerSafeTypes.cs
+++ b/DeepCloner.Core/Helpers/DeepClonerSafeTypes.cs
@@ -31,7 +31,7 @@ internal static class DeepClonerSafeTypes
         [typeof(IntPtr)] = true,
         [typeof(UIntPtr)] = true,
         [typeof(Guid)] = true,
-        
+
         // Others
         [typeof(DBNull)] = true,
         [StringComparer.Ordinal.GetType()] = true,
@@ -60,6 +60,14 @@ internal static class DeepClonerSafeTypes
         // pointers (e.g. int*) are unsafe, but we cannot do anything with it except blind copy
         if (type.IsEnum() || type.IsPointer)
         {
+            KnownTypes.TryAdd(type, true);
+            return true;
+        }
+
+        // Type.FullName can be null for certain types
+        if (type.FullName == null)
+        {
+            // return true because they should not clone
             KnownTypes.TryAdd(type, true);
             return true;
         }


### PR DESCRIPTION
fixed bug: some types may occur NullReferenceException from DeepClonerSafeTypes.CanReturnSameType() because its Type.FullName can be null.